### PR TITLE
add logic to reload tonic desk on any desk write

### DIFF
--- a/tonic/lib/tonic.hoon
+++ b/tonic/lib/tonic.hoon
@@ -11,10 +11,20 @@
 |%
 ++  cass               ::  the latest $cass for the given $bowl
   |=  =bowl:gall
-  ^-  cass:clay
+  ^-  card:agent:gall
   =/  our  (scot %p our.bowl)
-  =/  wen  (scot %da now.bowl)
-  .^(cass:clay /cw/[our]/[q.byk.bowl]/[wen])
+  =/  now  (scot %da now.bowl)
+  :*  %give  %fact
+      ~[/tonic/current]
+      cass+!>(.^(cass:clay /cw/[our]/[q.byk.bowl]/[now]))
+  ==
+++  next               ::  card to subscribe to desk file updates
+  |=  =bowl:gall
+  ^-  card:agent:gall
+  :*  %pass  /tonic/update
+      %arvo  %c
+      [%warp our.bowl q.byk.bowl ~ %next %x da+now.bowl /]
+  ==
 --
 |%
 ++  agent
@@ -36,8 +46,7 @@
     ^-  (quip card:agent:gall agent:gall)
     =^  cards  agent  (on-load:ag ole)
     :_  this
-    %+  snoc  cards
-    [%give %fact ~[/tonic/current] cass+!>((cass bowl))]
+    (welp cards ~[(cass bowl) (next bowl)])
   ::
   ++  on-watch
     |=  =path
@@ -47,8 +56,7 @@
       [cards this]
     :_  this
     ?+    path  ~|(bad-watch/path !!)
-        [%tonic %current ~]
-      [%give %fact ~[/tonic/current] cass+!>((cass bowl))]~
+      [%tonic %current ~]  [(cass bowl)]~
     ==
   ::
   ++  on-agent
@@ -74,8 +82,13 @@
   ++  on-arvo
     |=  [=wire =sign-arvo:agent:gall]
     ^-  (quip card:agent:gall agent:gall)
-    =^  cards  agent  (on-arvo:ag wire sign-arvo)
-    [cards this]
+    ?.  ?=([%tonic *] wire)
+      =^  cards  agent  (on-arvo:ag wire sign-arvo)
+      [cards this]
+    :_  this
+    ?+    wire  ~|(bad-arvo/wire !!)
+      [%tonic %update ~]  ~[(cass bowl) (next bowl)]
+    ==
   ::
   ++  on-fail
     |=  [=term =tang]


### PR DESCRIPTION
These changes modify the behavior of the `tonic` wrapper so that it reloads the front-end whenever:

1. The wrapped app is `+on-load`ed (existing behavior), or
2. The desk hosting the wrapped app has a file update (tracked with [`%next` `%clay` subscription](https://docs.urbit.org/system/kernel/clay/reference/tasks#next---await-next))

The new behavior is particularly useful for apps like [`%wiki`](https://github.com/JohnRillos/wiki) and [`%fund`](https://github.com/tocwex/fund), which load JS and CSS files at runtime in order to shorten UI tweak iteration time.

-----

I only ran a few simple test cases to verify the new functionality, i.e.:

- The front-end still reloads when the app is recompiled
- The front-end now reloads when any desk file is updated
- Desk file updates still occur when interleaved with recompilations

I'd recommend waiting a week or two before merging so I can use the changes in production for more thorough testing!

Thanks and let me know if you have any questions or suggestions!